### PR TITLE
Allow skipping of non-english documents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -422,5 +422,10 @@
       <artifactId>commons-csv</artifactId>
       <version>1.8</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-core</artifactId>
+      <version>1.24.1</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/io/anserini/collection/SourceDocument.java
+++ b/src/main/java/io/anserini/collection/SourceDocument.java
@@ -15,6 +15,8 @@
  */
 
 package io.anserini.collection;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.language.LanguageIdentifier;
 
 /**
  * A raw document from a collection. A {@code SourceDocument} is explicitly distinguish a from a
@@ -50,4 +52,9 @@ public interface SourceDocument {
    * @return <code>true</code> if this document is meant to be indexed
    */
   boolean indexable();
+
+  default boolean isEnglish(String content) throws TikaException{
+    LanguageIdentifier identifier = new LanguageIdentifier(content);
+    return identifier.getLanguage().equals("en");
+  }
 }

--- a/src/main/java/io/anserini/index/IndexArgs.java
+++ b/src/main/java/io/anserini/index/IndexArgs.java
@@ -118,6 +118,11 @@ public class IndexArgs {
       usage = "Analyzer language (ISO 3166 two-letter code).")
   public String language= "en";
 
+  @Option(name = "-skipNonEnglish",
+          usage = "Boolean to skip non-English documents.")
+  public boolean skipNonEnglish = false;
+
+
   // Tweet options
 
   @Option(name = "-tweet.keepRetweets",


### PR DESCRIPTION
This uses Apache Tika to detect language in a document and skip indexing it if it is not in English.

To use, include `-skipNonEnglish` with indexing command. 